### PR TITLE
fix(interop): fix export and use commonJS

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,4 +34,4 @@ function createSharedReactContext<T>(
   return context;
 }
 
-export default createSharedReactContext;
+export = createSharedReactContext;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,12 @@
   "compilerOptions": {
     "jsx": "react",
     "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "types": ["node"],
     "outDir": "./dist",
     "allowJs": true,
     "target": "es6",
+    "module": "commonjs",
     "moduleResolution": "node",
     "strict": true
   },


### PR DESCRIPTION
Fixes Jest not recognizing create-shared-react-context by changing export, enabling esModuleInterop, and reverting to commonJS.

Tested by running Jest tests that had previously failed before fixes and confirming functionality works between modules.